### PR TITLE
Fix email defaults and hostel detail links

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,8 @@ CORS(app, origins=allowed_origins, supports_credentials=True)
 
 # ========== EMAIL CONFIGURATION ==========
 app.config['MAIL_SERVER'] = os.environ.get('MAIL_SERVER')
-app.config['MAIL_PORT'] = int(os.environ.get('MAIL_PORT'))
+# Default to 587 if MAIL_PORT is not provided to avoid TypeError
+app.config['MAIL_PORT'] = int(os.environ.get('MAIL_PORT', '587'))
 app.config['MAIL_USE_TLS'] = os.environ.get('MAIL_USE_TLS') == 'True'
 app.config['MAIL_USERNAME'] = os.environ.get('MAIL_USERNAME')
 app.config['MAIL_PASSWORD'] = os.environ.get('MAIL_PASSWORD')

--- a/hostels.html
+++ b/hostels.html
@@ -84,7 +84,7 @@
           <img src="/assets/images/phase1/phase1-progress-2.jpg" alt="Phase 1 Progress 2" class="rounded-lg shadow-lg hover:shadow-xl transition" />
           <img src="/assets/images/phase1/phase1-progress-3.jpg" alt="Phase 1 Progress 3" class="rounded-lg shadow-lg hover:shadow-xl transition" />
         </div>
-        <a href="/hostel-detail" class="mt-6 inline-block bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">View More</a>
+        <a href="/hostels/detail" class="mt-6 inline-block bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">View More</a>
       </div>
     </section>
 
@@ -105,7 +105,7 @@
           <p class="text-sm font-medium text-gray-400 mb-2">Near Kwara State University (KWASU)</p>
           <p class="text-sm font-medium text-gray-400 mb-4">Estimated Completion: End of 2025</p>
           <span class="inline-block bg-yellow-500 text-gray-900 px-3 py-1 rounded-full text-sm font-semibold mb-4">Ongoing Construction 🚧</span>
-          <a href="/hostel-detail" class="block text-center bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">View Details</a>
+          <a href="/hostels/detail" class="block text-center bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">View Details</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- avoid TypeError when `MAIL_PORT` is unset
- link hostel listing buttons to correct route

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_6865cbad44d08327b1057589751bd004